### PR TITLE
[FIXES] silent failure of rsync and removal of "hot" file

### DIFF
--- a/prod-images/base/Dockerfile
+++ b/prod-images/base/Dockerfile
@@ -15,6 +15,7 @@ RUN npm run build
 FROM php:8.2-fpm-alpine AS base
 
 RUN apk add --no-cache \
+    rsync \
     freetype-dev \
     libjpeg-turbo-dev \
     libpng-dev \
@@ -32,7 +33,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local
 
 COPY ./src/laravel/ ./
 
-RUN rm -f /public/hot
+RUN rm -f /var/www/html/laravel/public/hot
 RUN rm -rf /storage/framework/views/*
 
 COPY ./src/laravel/prod-files/.env /var/www/html/laravel/.env


### PR DESCRIPTION
Issues found + fix:

- Silent failure of rsync shell script. Caused by fpm alpine image not including rsync, leading to app-data old volumes being served instead of new app-data from newly pushed images. Resolved by installing rsync package in base Dockerfile.
- Issue with hot file not removing when transitioning from development to production. Fixed by refactoring path in base Dockerfile.